### PR TITLE
minor updates to ui / keyboard input changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ build-BNEditor-Desktop_Qt_5_2_0_MinGW_32bit-Debug/
 build-BNEditor-Desktop_Qt_5_2_0_MinGW_32bit-Release/
 build-BNEditor-Desktop_Qt_5_4_1_MinGW_32bit-Debug/
 build-BNEditor-Desktop_Qt_5_4_1_MinGW_32bit-Release/
-
+build-*
 
 *.user

--- a/source/beamdefaultsdialog.ui
+++ b/source/beamdefaultsdialog.ui
@@ -10,6 +10,11 @@
     <height>543</height>
    </rect>
   </property>
+  <property name="font">
+   <font>
+    <pointsize>5</pointsize>
+   </font>
+  </property>
   <property name="windowTitle">
    <string>Arguments Editor</string>
   </property>

--- a/source/blueprints.ui
+++ b/source/blueprints.ui
@@ -10,6 +10,11 @@
     <height>357</height>
    </rect>
   </property>
+  <property name="font">
+   <font>
+    <pointsize>5</pointsize>
+   </font>
+  </property>
   <property name="windowTitle">
    <string>Blueprints</string>
   </property>
@@ -294,7 +299,7 @@
     <rect>
      <x>30</x>
      <y>20</y>
-     <width>211</width>
+     <width>290</width>
      <height>31</height>
     </rect>
    </property>

--- a/source/glwidget.cpp
+++ b/source/glwidget.cpp
@@ -465,7 +465,7 @@ void GLWidget::drawpicking()
     GLubyte pixel[3];
     GLint viewport[4];
     glGetIntegerv(GL_VIEWPORT,viewport);
-
+    glEnable(GL_LIGHTING);
     //glReadPixels(cursorX,viewport[3]-cursorY,1,1,GL_RGB,GL_UNSIGNED_BYTE,(void *)pixel);
     glReadPixels(lastPos.x(), viewport[3]-lastPos.y(), 1, 1, GL_RGB, GL_UNSIGNED_BYTE, (void *) pixel);
     qDebug() << pixel[0] << ", " << pixel[1] << "," << pixel[2];
@@ -484,7 +484,7 @@ void GLWidget::drawpicking()
         }
     }
 
-    glEnable(GL_LIGHTING);
+
 
     // Turn on antialiasing
     glEnable (GL_BLEND);
@@ -830,7 +830,7 @@ void GLWidget::initializeGL()
 }
 
 void GLWidget::paintGL()
-{  
+{
     /* Set background color */
     glClearColor(backgroundcolor.at(0), backgroundcolor.at(1), backgroundcolor.at(2), backgroundcolor.at(3));
 
@@ -2367,7 +2367,7 @@ void GLWidget::DrawRectSelect()
 {
     QVector4D test,RectSel_1V,RectSel_2V,RectSel_3V,RectSel_4V;
 
-    /*
+
     glBegin(GL_POINTS);
     glColor3f(0.0, 1.0, 0.0);
     for(int i=0; i<20 ; i++)
@@ -2398,7 +2398,7 @@ void GLWidget::DrawRectSelect()
         glVertex3d(test.x(), test.y(), test.z());
     }
 
-    glEnd();*/
+    glEnd();
 
     glLineStipple(1, 0x3F07);
     glEnable(GL_LINE_STIPPLE);
@@ -2435,7 +2435,7 @@ void GLWidget::DrawRectSelect()
     QVector3D normal_4 = QVector3D::crossProduct(vec2,vec4);
     //qDebug() << normal_1 << normal_2 << normal_3 << normal_4;
 
-    /* Draw selection plane normals
+    /* Draw selection plane normals*/
     glBegin(GL_LINES);
     QVector3D campos2 = campos.toVector3D();
     QVector3D normal = campos2 + normal_1;
@@ -2455,7 +2455,7 @@ void GLWidget::DrawRectSelect()
     glVertex3d(campos.x(), campos.y(), campos.z());
 
 
-    glEnd();*/
+    glEnd();
 
 }
 
@@ -2470,38 +2470,38 @@ void GLWidget::keyPressEvent(QKeyEvent * event)
 
     QVector3D CameraLeft = QVector3D::crossProduct(CameraDirection,CameraUpVector);
 
-    if(event->key() == Qt::Key_4)
+    if(event->key() == Qt::Key_Left || event->key() == Qt::Key_A)
     {
         ViewOffsetX += CameraLeft.x()*0.2f;
         ViewOffsetY += CameraLeft.y()*0.2f;
         updateGL();
     }
-    else if(event->key() == Qt::Key_6)
+    else if(event->key() == Qt::Key_Right || event->key() == Qt::Key_D)
     {
         ViewOffsetX -= CameraLeft.x()*0.2f;
         ViewOffsetY -= CameraLeft.y()*0.2f;
         updateGL();
     }
-    else if(event->key() == Qt::Key_8)
+    else if(event->key() == Qt::Key_Equal || event->key() == Qt::Key_W)
     {
         ViewOffsetX -= CameraDirection.x()*0.2f;
         ViewOffsetY -= CameraDirection.y()*0.2f;
-        //ViewOffsetZ -= CameraDirection.z()*0.2f;
+       // ViewOffsetZ -= CameraDirection.z()*0.2f;
         updateGL();
     }
-    else if(event->key() == Qt::Key_2)
+    else if(event->key() == Qt::Key_Minus || event->key() == Qt::Key_S)
     {
         ViewOffsetX += CameraDirection.x()*0.2f;
         ViewOffsetY += CameraDirection.y()*0.2f;
-        //ViewOffsetZ += CameraDirection.z()*0.2f;
+       // ViewOffsetZ += CameraDirection.z()*0.2f;
         updateGL();
     }
-    else if(event->key() == Qt::Key_7)
+    else if(event->key() == Qt::Key_Up || event->key() == Qt::Key_E)
     {
         ViewOffsetZ -= 0.1f;
         updateGL();
     }
-    else if(event->key() == Qt::Key_1)
+    else if(event->key() == Qt::Key_Down || event->key() == Qt::Key_Q)
     {
         ViewOffsetZ += 0.1f;
         updateGL();

--- a/source/inputdialog.ui
+++ b/source/inputdialog.ui
@@ -10,6 +10,11 @@
     <height>280</height>
    </rect>
   </property>
+  <property name="font">
+   <font>
+    <pointsize>5</pointsize>
+   </font>
+  </property>
   <property name="windowTitle">
    <string>Dialog</string>
   </property>

--- a/source/mainwindow.ui
+++ b/source/mainwindow.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1159</width>
-    <height>771</height>
+    <width>1485</width>
+    <height>906</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -18,6 +18,11 @@
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
+  </property>
+  <property name="font">
+   <font>
+    <pointsize>5</pointsize>
+   </font>
   </property>
   <property name="windowTitle">
    <string>MainWindow</string>
@@ -39,21 +44,26 @@
    <bool>false</bool>
   </property>
   <widget class="QWidget" name="centralWidget">
+   <property name="font">
+    <font>
+     <pointsize>5</pointsize>
+    </font>
+   </property>
    <property name="styleSheet">
     <string notr="true">QWidget#centralWidget {
-/*	background-color: qlineargradient(spread:pad, x1:0, y1:1, x2:0, y2:0, stop:0 rgba(121, 121, 121, 255), stop:1 rgba(207, 207, 207, 255));
+/*  background-color: qlineargradient(spread:pad, x1:0, y1:1, x2:0, y2:0, stop:0 rgba(121, 121, 121, 255), stop:1 rgba(207, 207, 207, 255));
 */
 background-color: qlineargradient(spread:pad, x1:0, y1:1, x2:0, y2:0, stop:0  rgba(83, 93, 108, 255), stop:1 rgba(207, 207, 207, 255));
 
 
 }
 QToolButton {
-	background-color: #e2e2e2;
+    background-color: #e2e2e2;
      border-style: outset;
      border-width: 0px;
     
-	
-	color: rgb(0, 0, 0);
+    
+    color: rgb(0, 0, 0);
      padding: 6px;
 }
 QToolButton:checked {
@@ -75,22 +85,22 @@ QToolButton:hover {
 
 }
 QToolButton:disabled {
-	background-color: #e2e2e2;
+    background-color: #e2e2e2;
      border-style: outset;
      border-width: 0px;
 
-	
-	color: rgb(150, 150, 150);
+    
+    color: rgb(150, 150, 150);
      padding: 6px;
 }
 QPushButton {
-	background-color: rgb(68, 68, 68);
+    background-color: rgb(68, 68, 68);
      border-style: solid;
      border-width: 3px;
      border-radius: 0px;
      border-color: #B3B3B3;
 
-	 color: rgb(255, 255, 255);
+     color: rgb(255, 255, 255);
      padding: 6px;
 }
  QPushButton:checked {
@@ -102,39 +112,39 @@ QPushButton {
      border-style: inset;
  }
 QPushButton:Disabled {
-	background-color: rgb(68, 68, 68);
+    background-color: rgb(68, 68, 68);
      border-style: outset;
      border-width: 2px;
      border-radius: 0px;
      border-color: grey;
 
-	
-	color: grey;
+    
+    color: grey;
      padding: 6px;
 }
 QWidget#tab {
-	background-color:  #e2e2e2;
+    background-color:  #e2e2e2;
 }
 QWidget#tab_2 {
-	background-color:  #e2e2e2;
+    background-color:  #e2e2e2;
 }
 QWidget#tab_3 {
-	background-color:  #e2e2e2;
+    background-color:  #e2e2e2;
 }
 QWidget#tab_4 {
-	background-color:  #e2e2e2;
+    background-color:  #e2e2e2;
 }
 QWidget#tab_5 {
-	background-color:  #e2e2e2;
+    background-color:  #e2e2e2;
 }
 QWidget#tab_nodes {
-	background-color:  #e2e2e2;
+    background-color:  #e2e2e2;
 }
 QWidget#tab_beams {
-	background-color:  #e2e2e2;
+    background-color:  #e2e2e2;
 }
 QWidget#tab_wheels {
-	background-color:  #e2e2e2;
+    background-color:  #e2e2e2;
 }
  QTabWidget::pane { /* The tab widget frame */
      border-top: 2px solid #e2e2e2;
@@ -159,7 +169,7 @@ QTabWidget::tab-bar {
     /* background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
                                  stop: 0 #fafafa, stop: 0.4 #f4f4f4,
                                  stop: 0.5 #e7e7e7, stop: 1.0 #fafafa);*/
-	background:  #e2e2e2;
+    background:  #e2e2e2;
 
  }
 
@@ -204,6 +214,11 @@ QTabWidget::tab-bar {
         <height>131</height>
        </size>
       </property>
+      <property name="font">
+       <font>
+        <pointsize>5</pointsize>
+       </font>
+      </property>
       <property name="styleSheet">
        <string notr="true"/>
       </property>
@@ -240,10 +255,15 @@ QTabWidget::tab-bar {
            <height>0</height>
           </size>
          </property>
+         <property name="font">
+          <font>
+           <pointsize>5</pointsize>
+          </font>
+         </property>
          <property name="styleSheet">
           <string notr="true">QGroupBox#groupBox {
-	
-	border-color: rgb(223, 223, 223);
+    
+    border-color: rgb(223, 223, 223);
 
 }</string>
          </property>
@@ -251,6 +271,11 @@ QTabWidget::tab-bar {
           <number>0</number>
          </property>
          <widget class="QWidget" name="tab">
+          <property name="font">
+           <font>
+            <pointsize>5</pointsize>
+           </font>
+          </property>
           <attribute name="title">
            <string>Nodes</string>
           </attribute>
@@ -258,10 +283,15 @@ QTabWidget::tab-bar {
            <property name="geometry">
             <rect>
              <x>950</x>
-             <y>10</y>
-             <width>161</width>
-             <height>81</height>
+             <y>0</y>
+             <width>300</width>
+             <height>100</height>
             </rect>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
            </property>
            <property name="frameShape">
             <enum>QFrame::StyledPanel</enum>
@@ -273,10 +303,15 @@ QTabWidget::tab-bar {
             <property name="geometry">
              <rect>
               <x>10</x>
-              <y>20</y>
-              <width>141</width>
-              <height>20</height>
+              <y>60</y>
+              <width>130</width>
+              <height>30</height>
              </rect>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
             </property>
             <property name="text">
              <string>Show node ID's</string>
@@ -288,11 +323,16 @@ QTabWidget::tab-bar {
             </property>
             <property name="geometry">
              <rect>
-              <x>10</x>
-              <y>40</y>
-              <width>131</width>
-              <height>20</height>
+              <x>150</x>
+              <y>20</y>
+              <width>150</width>
+              <height>30</height>
              </rect>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
             </property>
             <property name="text">
              <string>Draw triangles</string>
@@ -301,11 +341,16 @@ QTabWidget::tab-bar {
            <widget class="QCheckBox" name="checkBox">
             <property name="geometry">
              <rect>
-              <x>10</x>
+              <x>150</x>
               <y>60</y>
-              <width>141</width>
-              <height>20</height>
+              <width>150</width>
+              <height>30</height>
              </rect>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
             </property>
             <property name="text">
              <string>Show node names</string>
@@ -315,10 +360,15 @@ QTabWidget::tab-bar {
             <property name="geometry">
              <rect>
               <x>10</x>
-              <y>0</y>
-              <width>101</width>
-              <height>21</height>
+              <y>20</y>
+              <width>130</width>
+              <height>30</height>
              </rect>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
             </property>
             <property name="text">
              <string>Snap to grid</string>
@@ -333,6 +383,11 @@ QTabWidget::tab-bar {
              <width>71</width>
              <height>101</height>
             </rect>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Add</string>
@@ -363,6 +418,11 @@ QTabWidget::tab-bar {
              <height>101</height>
             </rect>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
+           </property>
            <property name="text">
             <string>Move</string>
            </property>
@@ -391,6 +451,11 @@ QTabWidget::tab-bar {
              <width>71</width>
              <height>101</height>
             </rect>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Scale</string>
@@ -421,6 +486,11 @@ QTabWidget::tab-bar {
              <height>101</height>
             </rect>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
+           </property>
            <property name="text">
             <string>Rotate</string>
            </property>
@@ -450,6 +520,11 @@ QTabWidget::tab-bar {
              <height>101</height>
             </rect>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
+           </property>
            <property name="text">
             <string>Duplicate</string>
            </property>
@@ -475,6 +550,11 @@ QTabWidget::tab-bar {
              <width>81</width>
              <height>101</height>
             </rect>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Rect. Select</string>
@@ -508,6 +588,11 @@ QTabWidget::tab-bar {
              <height>101</height>
             </rect>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
+           </property>
            <property name="text">
             <string>Delete</string>
            </property>
@@ -534,6 +619,11 @@ QTabWidget::tab-bar {
              <height>31</height>
             </rect>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
+           </property>
            <property name="text">
             <string>Extrude</string>
            </property>
@@ -549,6 +639,11 @@ QTabWidget::tab-bar {
              <width>61</width>
              <height>31</height>
             </rect>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Mirror</string>
@@ -569,6 +664,11 @@ QTabWidget::tab-bar {
              <height>31</height>
             </rect>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
+           </property>
            <property name="text">
             <string>Array</string>
            </property>
@@ -585,18 +685,33 @@ QTabWidget::tab-bar {
              <height>101</height>
             </rect>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
+           </property>
            <property name="currentIndex">
             <number>0</number>
            </property>
            <widget class="QWidget" name="page_3">
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
+            </property>
             <widget class="QSpinBox" name="spinBox_grids">
              <property name="geometry">
               <rect>
-               <x>80</x>
-               <y>20</y>
-               <width>61</width>
-               <height>22</height>
+               <x>70</x>
+               <y>10</y>
+               <width>60</width>
+               <height>30</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="minimum">
               <number>1</number>
@@ -614,11 +729,16 @@ QTabWidget::tab-bar {
             <widget class="QLabel" name="label_7grids">
              <property name="geometry">
               <rect>
-               <x>20</x>
-               <y>20</y>
-               <width>61</width>
-               <height>21</height>
+               <x>10</x>
+               <y>10</y>
+               <width>80</width>
+               <height>30</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="text">
               <string>Grid size</string>
@@ -632,6 +752,11 @@ QTabWidget::tab-bar {
                <width>88</width>
                <height>31</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="toolTip">
               <string>Print node name in JBEAM textedit at cursor position.</string>
@@ -664,6 +789,11 @@ QTabWidget::tab-bar {
                <height>31</height>
               </rect>
              </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
+             </property>
              <property name="toolTip">
               <string>Print node name in JBEAM textedit at cursor position.</string>
              </property>
@@ -688,6 +818,11 @@ QTabWidget::tab-bar {
             </widget>
            </widget>
            <widget class="QWidget" name="page">
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
+            </property>
             <widget class="QComboBox" name="comboBox_2">
              <property name="geometry">
               <rect>
@@ -696,6 +831,11 @@ QTabWidget::tab-bar {
                <width>131</width>
                <height>25</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
             </widget>
             <widget class="QToolButton" name="toolButton_13">
@@ -706,6 +846,11 @@ QTabWidget::tab-bar {
                <width>51</width>
                <height>31</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="text">
               <string>Apply</string>
@@ -720,6 +865,11 @@ QTabWidget::tab-bar {
                <height>20</height>
               </rect>
              </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
+             </property>
             </widget>
             <widget class="QLabel" name="label_zcoordinate_2">
              <property name="geometry">
@@ -729,6 +879,11 @@ QTabWidget::tab-bar {
                <width>81</width>
                <height>21</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="text">
               <string>Name prefix</string>
@@ -743,6 +898,11 @@ QTabWidget::tab-bar {
                <height>20</height>
               </rect>
              </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
+             </property>
              <property name="toolTip">
               <string>The Z coordinate of new nodes.</string>
              </property>
@@ -755,6 +915,11 @@ QTabWidget::tab-bar {
                <width>81</width>
                <height>21</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="text">
               <string>Z coordinate</string>
@@ -769,12 +934,22 @@ QTabWidget::tab-bar {
                <height>21</height>
               </rect>
              </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
+             </property>
              <property name="text">
               <string>Node group</string>
              </property>
             </widget>
            </widget>
            <widget class="QWidget" name="page_2">
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
+            </property>
             <widget class="QFrame" name="frame_7">
              <property name="geometry">
               <rect>
@@ -783,6 +958,11 @@ QTabWidget::tab-bar {
                <width>171</width>
                <height>101</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="frameShape">
               <enum>QFrame::StyledPanel</enum>
@@ -799,6 +979,11 @@ QTabWidget::tab-bar {
                 <height>22</height>
                </rect>
               </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
+              </property>
              </widget>
              <widget class="QLineEdit" name="lineEdit_movey">
               <property name="geometry">
@@ -808,6 +993,11 @@ QTabWidget::tab-bar {
                 <width>81</width>
                 <height>22</height>
                </rect>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
               </property>
              </widget>
              <widget class="QLineEdit" name="lineEdit_movez">
@@ -819,6 +1009,11 @@ QTabWidget::tab-bar {
                 <height>22</height>
                </rect>
               </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
+              </property>
              </widget>
              <widget class="QLabel" name="label_zcoordinate_4">
               <property name="geometry">
@@ -828,6 +1023,11 @@ QTabWidget::tab-bar {
                 <width>31</width>
                 <height>21</height>
                </rect>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
               </property>
               <property name="text">
                <string>X</string>
@@ -842,6 +1042,11 @@ QTabWidget::tab-bar {
                 <height>21</height>
                </rect>
               </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
+              </property>
               <property name="text">
                <string>Y</string>
               </property>
@@ -854,6 +1059,11 @@ QTabWidget::tab-bar {
                 <width>31</width>
                 <height>21</height>
                </rect>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
               </property>
               <property name="text">
                <string>Z</string>
@@ -868,6 +1078,11 @@ QTabWidget::tab-bar {
                 <height>31</height>
                </rect>
               </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
+              </property>
               <property name="text">
                <string>Move (meters)</string>
               </property>
@@ -880,6 +1095,11 @@ QTabWidget::tab-bar {
                 <width>51</width>
                 <height>31</height>
                </rect>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
               </property>
               <property name="text">
                <string>Move</string>
@@ -894,6 +1114,11 @@ QTabWidget::tab-bar {
                 <height>31</height>
                </rect>
               </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
+              </property>
               <property name="text">
                <string>Reset</string>
               </property>
@@ -901,6 +1126,11 @@ QTabWidget::tab-bar {
             </widget>
            </widget>
            <widget class="QWidget" name="page_4">
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
+            </property>
             <widget class="QFrame" name="frame_9">
              <property name="geometry">
               <rect>
@@ -909,6 +1139,11 @@ QTabWidget::tab-bar {
                <width>171</width>
                <height>101</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="frameShape">
               <enum>QFrame::StyledPanel</enum>
@@ -925,6 +1160,11 @@ QTabWidget::tab-bar {
                 <height>31</height>
                </rect>
               </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
+              </property>
               <property name="text">
                <string>Scale</string>
               </property>
@@ -937,6 +1177,11 @@ QTabWidget::tab-bar {
                 <width>31</width>
                 <height>21</height>
                </rect>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
               </property>
               <property name="text">
                <string>X</string>
@@ -951,6 +1196,11 @@ QTabWidget::tab-bar {
                 <height>21</height>
                </rect>
               </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
+              </property>
               <property name="text">
                <string>Y</string>
               </property>
@@ -963,6 +1213,11 @@ QTabWidget::tab-bar {
                 <width>31</width>
                 <height>21</height>
                </rect>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
               </property>
               <property name="text">
                <string>Z</string>
@@ -977,6 +1232,11 @@ QTabWidget::tab-bar {
                 <height>22</height>
                </rect>
               </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
+              </property>
              </widget>
              <widget class="QLineEdit" name="lineEdit_scaley">
               <property name="geometry">
@@ -986,6 +1246,11 @@ QTabWidget::tab-bar {
                 <width>81</width>
                 <height>22</height>
                </rect>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
               </property>
              </widget>
              <widget class="QLineEdit" name="lineEdit_scalez">
@@ -997,6 +1262,11 @@ QTabWidget::tab-bar {
                 <height>22</height>
                </rect>
               </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
+              </property>
              </widget>
              <widget class="QToolButton" name="toolButton_28">
               <property name="geometry">
@@ -1006,6 +1276,11 @@ QTabWidget::tab-bar {
                 <width>51</width>
                 <height>31</height>
                </rect>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
               </property>
               <property name="text">
                <string>Scale</string>
@@ -1020,6 +1295,11 @@ QTabWidget::tab-bar {
                 <height>31</height>
                </rect>
               </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
+              </property>
               <property name="text">
                <string>Reset</string>
               </property>
@@ -1027,6 +1307,11 @@ QTabWidget::tab-bar {
             </widget>
            </widget>
            <widget class="QWidget" name="page_5">
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
+            </property>
             <widget class="QFrame" name="frame_8">
              <property name="geometry">
               <rect>
@@ -1035,6 +1320,11 @@ QTabWidget::tab-bar {
                <width>171</width>
                <height>101</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="frameShape">
               <enum>QFrame::StyledPanel</enum>
@@ -1051,6 +1341,11 @@ QTabWidget::tab-bar {
                 <height>31</height>
                </rect>
               </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
+              </property>
               <property name="text">
                <string>Rotate (degrees)</string>
               </property>
@@ -1064,6 +1359,11 @@ QTabWidget::tab-bar {
                 <height>22</height>
                </rect>
               </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
+              </property>
              </widget>
              <widget class="QLineEdit" name="lineEdit_rotatey">
               <property name="geometry">
@@ -1073,6 +1373,11 @@ QTabWidget::tab-bar {
                 <width>81</width>
                 <height>22</height>
                </rect>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
               </property>
              </widget>
              <widget class="QLineEdit" name="lineEdit_rotatez">
@@ -1084,6 +1389,11 @@ QTabWidget::tab-bar {
                 <height>22</height>
                </rect>
               </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
+              </property>
              </widget>
              <widget class="QLabel" name="label_zcoordinate_9">
               <property name="geometry">
@@ -1093,6 +1403,11 @@ QTabWidget::tab-bar {
                 <width>31</width>
                 <height>21</height>
                </rect>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
               </property>
               <property name="text">
                <string>X</string>
@@ -1107,6 +1422,11 @@ QTabWidget::tab-bar {
                 <height>21</height>
                </rect>
               </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
+              </property>
               <property name="text">
                <string>Y</string>
               </property>
@@ -1119,6 +1439,11 @@ QTabWidget::tab-bar {
                 <width>31</width>
                 <height>21</height>
                </rect>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
               </property>
               <property name="text">
                <string>Z</string>
@@ -1133,6 +1458,11 @@ QTabWidget::tab-bar {
                 <height>31</height>
                </rect>
               </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
+              </property>
               <property name="text">
                <string>Rotate</string>
               </property>
@@ -1146,6 +1476,11 @@ QTabWidget::tab-bar {
                 <height>31</height>
                </rect>
               </property>
+              <property name="font">
+               <font>
+                <pointsize>5</pointsize>
+               </font>
+              </property>
               <property name="text">
                <string>Reset</string>
               </property>
@@ -1153,6 +1488,11 @@ QTabWidget::tab-bar {
             </widget>
            </widget>
            <widget class="QWidget" name="page_6">
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
+            </property>
             <widget class="QSpinBox" name="spinBox_2">
              <property name="geometry">
               <rect>
@@ -1161,6 +1501,11 @@ QTabWidget::tab-bar {
                <width>61</width>
                <height>21</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
             </widget>
             <widget class="QLabel" name="label_11">
@@ -1171,6 +1516,11 @@ QTabWidget::tab-bar {
                <width>53</width>
                <height>21</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="text">
               <string>Count</string>
@@ -1185,6 +1535,11 @@ QTabWidget::tab-bar {
                <height>31</height>
               </rect>
              </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
+             </property>
              <property name="text">
               <string>Array - Offset</string>
              </property>
@@ -1197,6 +1552,11 @@ QTabWidget::tab-bar {
                <width>21</width>
                <height>21</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="text">
               <string>X:</string>
@@ -1211,6 +1571,11 @@ QTabWidget::tab-bar {
                <height>21</height>
               </rect>
              </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
+             </property>
              <property name="text">
               <string>Y:</string>
              </property>
@@ -1223,6 +1588,11 @@ QTabWidget::tab-bar {
                <width>21</width>
                <height>21</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="text">
               <string>Z:</string>
@@ -1237,6 +1607,11 @@ QTabWidget::tab-bar {
                <height>21</height>
               </rect>
              </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
+             </property>
             </widget>
             <widget class="QLineEdit" name="lineEdit_10">
              <property name="geometry">
@@ -1246,6 +1621,11 @@ QTabWidget::tab-bar {
                <width>81</width>
                <height>21</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
             </widget>
             <widget class="QLineEdit" name="lineEdit_11">
@@ -1257,6 +1637,11 @@ QTabWidget::tab-bar {
                <height>21</height>
               </rect>
              </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
+             </property>
             </widget>
             <widget class="QCheckBox" name="checkBox_4">
              <property name="enabled">
@@ -1265,10 +1650,15 @@ QTabWidget::tab-bar {
              <property name="geometry">
               <rect>
                <x>230</x>
-               <y>30</y>
-               <width>21</width>
-               <height>21</height>
+               <y>20</y>
+               <width>30</width>
+               <height>30</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="text">
               <string/>
@@ -1281,10 +1671,15 @@ QTabWidget::tab-bar {
              <property name="geometry">
               <rect>
                <x>140</x>
-               <y>30</y>
-               <width>81</width>
-               <height>20</height>
+               <y>20</y>
+               <width>90</width>
+               <height>30</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="text">
               <string>Merge nodes</string>
@@ -1299,6 +1694,11 @@ QTabWidget::tab-bar {
                <height>31</height>
               </rect>
              </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
+             </property>
              <property name="text">
               <string>Apply array</string>
              </property>
@@ -1312,20 +1712,35 @@ QTabWidget::tab-bar {
                <height>31</height>
               </rect>
              </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
+             </property>
              <property name="text">
               <string>Reset</string>
              </property>
             </widget>
            </widget>
            <widget class="QWidget" name="page_7">
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
+            </property>
             <widget class="QLabel" name="label_22">
              <property name="geometry">
               <rect>
-               <x>10</x>
+               <x>0</x>
                <y>0</y>
-               <width>101</width>
-               <height>31</height>
+               <width>100</width>
+               <height>10</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="text">
               <string>Mirror axis</string>
@@ -1335,10 +1750,15 @@ QTabWidget::tab-bar {
              <property name="geometry">
               <rect>
                <x>100</x>
-               <y>60</y>
-               <width>101</width>
-               <height>31</height>
+               <y>30</y>
+               <width>120</width>
+               <height>50</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="text">
               <string>Mirror selected</string>
@@ -1348,10 +1768,15 @@ QTabWidget::tab-bar {
              <property name="geometry">
               <rect>
                <x>10</x>
-               <y>30</y>
-               <width>81</width>
-               <height>20</height>
+               <y>10</y>
+               <width>80</width>
+               <height>30</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="text">
               <string>X</string>
@@ -1361,10 +1786,15 @@ QTabWidget::tab-bar {
              <property name="geometry">
               <rect>
                <x>10</x>
-               <y>50</y>
+               <y>40</y>
                <width>81</width>
-               <height>20</height>
+               <height>30</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="text">
               <string>Y</string>
@@ -1376,8 +1806,13 @@ QTabWidget::tab-bar {
                <x>10</x>
                <y>70</y>
                <width>81</width>
-               <height>20</height>
+               <height>30</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="text">
               <string>Z</string>
@@ -1387,17 +1822,27 @@ QTabWidget::tab-bar {
           </widget>
          </widget>
          <widget class="QWidget" name="tab_2">
+          <property name="font">
+           <font>
+            <pointsize>5</pointsize>
+           </font>
+          </property>
           <attribute name="title">
            <string>Beams</string>
           </attribute>
           <widget class="QComboBox" name="comboBox">
            <property name="geometry">
             <rect>
-             <x>310</x>
+             <x>320</x>
              <y>40</y>
-             <width>141</width>
+             <width>150</width>
              <height>28</height>
             </rect>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
            </property>
           </widget>
           <widget class="QToolButton" name="toolButton_8">
@@ -1405,9 +1850,14 @@ QTabWidget::tab-bar {
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>71</width>
+             <width>80</width>
              <height>101</height>
             </rect>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Add Single</string>
@@ -1432,11 +1882,16 @@ QTabWidget::tab-bar {
           <widget class="QToolButton" name="toolButton_9">
            <property name="geometry">
             <rect>
-             <x>70</x>
+             <x>80</x>
              <y>0</y>
-             <width>71</width>
+             <width>80</width>
              <height>101</height>
             </rect>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Add Cont</string>
@@ -1461,11 +1916,16 @@ QTabWidget::tab-bar {
           <widget class="QToolButton" name="toolButton_10">
            <property name="geometry">
             <rect>
-             <x>140</x>
+             <x>150</x>
              <y>0</y>
-             <width>71</width>
+             <width>80</width>
              <height>101</height>
             </rect>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Delete</string>
@@ -1493,11 +1953,16 @@ QTabWidget::tab-bar {
            </property>
            <property name="geometry">
             <rect>
-             <x>210</x>
+             <x>220</x>
              <y>0</y>
-             <width>71</width>
+             <width>80</width>
              <height>101</height>
             </rect>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Arguments</string>
@@ -1525,11 +1990,16 @@ QTabWidget::tab-bar {
            </property>
            <property name="geometry">
             <rect>
-             <x>460</x>
+             <x>470</x>
              <y>40</y>
-             <width>51</width>
+             <width>60</width>
              <height>31</height>
             </rect>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Apply</string>
@@ -1537,6 +2007,11 @@ QTabWidget::tab-bar {
           </widget>
          </widget>
          <widget class="QWidget" name="tab_5">
+          <property name="font">
+           <font>
+            <pointsize>5</pointsize>
+           </font>
+          </property>
           <attribute name="title">
            <string>Triangles</string>
           </attribute>
@@ -1551,6 +2026,11 @@ QTabWidget::tab-bar {
              <width>71</width>
              <height>101</height>
             </rect>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Add</string>
@@ -1571,11 +2051,16 @@ QTabWidget::tab-bar {
           <widget class="QToolButton" name="toolButton_35">
            <property name="geometry">
             <rect>
-             <x>60</x>
+             <x>70</x>
              <y>0</y>
-             <width>71</width>
+             <width>70</width>
              <height>101</height>
             </rect>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Flip</string>
@@ -1595,6 +2080,11 @@ QTabWidget::tab-bar {
           </widget>
          </widget>
          <widget class="QWidget" name="tab_4">
+          <property name="font">
+           <font>
+            <pointsize>5</pointsize>
+           </font>
+          </property>
           <attribute name="title">
            <string>Wheels</string>
           </attribute>
@@ -1606,9 +2096,14 @@ QTabWidget::tab-bar {
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>101</width>
+             <width>110</width>
              <height>101</height>
             </rect>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Add hubwheels</string>
@@ -1633,6 +2128,11 @@ QTabWidget::tab-bar {
           </widget>
          </widget>
          <widget class="QWidget" name="tab_3">
+          <property name="font">
+           <font>
+            <pointsize>5</pointsize>
+           </font>
+          </property>
           <attribute name="title">
            <string>Editor</string>
           </attribute>
@@ -1644,6 +2144,11 @@ QTabWidget::tab-bar {
              <width>1121</width>
              <height>101</height>
             </rect>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
            </property>
            <property name="frameShape">
             <enum>QFrame::StyledPanel</enum>
@@ -1663,6 +2168,11 @@ QTabWidget::tab-bar {
               <height>101</height>
              </rect>
             </property>
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
+            </property>
             <property name="text">
              <string>Test in BeamNG</string>
             </property>
@@ -1679,6 +2189,11 @@ QTabWidget::tab-bar {
               <height>101</height>
              </rect>
             </property>
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
+            </property>
             <property name="text">
              <string>Test in RoR</string>
             </property>
@@ -1694,6 +2209,11 @@ QTabWidget::tab-bar {
               <width>61</width>
               <height>101</height>
              </rect>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
             </property>
             <property name="toolTip">
              <string>Set scale of the blueprint by showing known distance</string>
@@ -1713,6 +2233,11 @@ QTabWidget::tab-bar {
               <width>81</width>
               <height>101</height>
              </rect>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
             </property>
             <property name="text">
              <string>Add other</string>
@@ -1739,6 +2264,11 @@ QTabWidget::tab-bar {
               <height>81</height>
              </rect>
             </property>
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
+            </property>
            </widget>
            <widget class="QLabel" name="label_10">
             <property name="geometry">
@@ -1748,6 +2278,11 @@ QTabWidget::tab-bar {
               <width>81</width>
               <height>31</height>
              </rect>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
             </property>
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Active tool:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1762,6 +2297,11 @@ QTabWidget::tab-bar {
               <height>31</height>
              </rect>
             </property>
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
+            </property>
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -1774,6 +2314,11 @@ QTabWidget::tab-bar {
               <width>291</width>
               <height>101</height>
              </rect>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
             </property>
             <property name="frameShape">
              <enum>QFrame::StyledPanel</enum>
@@ -1789,6 +2334,11 @@ QTabWidget::tab-bar {
                <width>71</width>
                <height>31</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="toolTip">
               <string>Import mesh from file</string>
@@ -1806,6 +2356,11 @@ QTabWidget::tab-bar {
                <height>31</height>
               </rect>
              </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
+             </property>
              <property name="text">
               <string>Reference 3D mesh (OBJ)</string>
              </property>
@@ -1818,6 +2373,11 @@ QTabWidget::tab-bar {
                <width>131</width>
                <height>21</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="maximum">
               <number>100</number>
@@ -1838,6 +2398,11 @@ QTabWidget::tab-bar {
                <height>31</height>
               </rect>
              </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
+             </property>
              <property name="text">
               <string>Opacity</string>
              </property>
@@ -1850,6 +2415,11 @@ QTabWidget::tab-bar {
                <width>61</width>
                <height>31</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="text">
               <string>File</string>
@@ -1866,6 +2436,11 @@ QTabWidget::tab-bar {
                <width>71</width>
                <height>31</height>
               </rect>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>5</pointsize>
+              </font>
              </property>
              <property name="toolTip">
               <string>Import mesh from file</string>
@@ -1898,6 +2473,11 @@ QTabWidget::tab-bar {
           <height>400</height>
          </size>
         </property>
+        <property name="font">
+         <font>
+          <pointsize>5</pointsize>
+         </font>
+        </property>
         <property name="frameShape">
          <enum>QFrame::StyledPanel</enum>
         </property>
@@ -1919,17 +2499,27 @@ QTabWidget::tab-bar {
          </property>
          <item>
           <widget class="QTabWidget" name="tabWidget">
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
+           </property>
            <property name="styleSheet">
             <string notr="true">QGroupBox#groupBox {
-	
-	border-color: rgb(223, 223, 223);
+    
+    border-color: rgb(223, 223, 223);
 
 }</string>
            </property>
            <property name="currentIndex">
-            <number>1</number>
+            <number>0</number>
            </property>
            <widget class="QWidget" name="JBEAM">
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
+            </property>
             <attribute name="title">
              <string>JBEAM</string>
             </attribute>
@@ -1971,6 +2561,7 @@ QTabWidget::tab-bar {
                 </property>
                 <property name="font">
                  <font>
+                  <pointsize>6</pointsize>
                   <weight>50</weight>
                   <italic>false</italic>
                   <bold>false</bold>
@@ -1992,6 +2583,11 @@ QTabWidget::tab-bar {
                   <height>35</height>
                  </rect>
                 </property>
+                <property name="font">
+                 <font>
+                  <pointsize>5</pointsize>
+                 </font>
+                </property>
                 <property name="toolTip">
                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add new nodes at current text cursor location&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
@@ -2007,6 +2603,11 @@ QTabWidget::tab-bar {
                   <width>40</width>
                   <height>35</height>
                  </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>5</pointsize>
+                 </font>
                 </property>
                 <property name="toolTip">
                  <string>Add new beams at current text cursor location</string>
@@ -2025,6 +2626,11 @@ QTabWidget::tab-bar {
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
             </property>
             <attribute name="title">
              <string>Nodes</string>
@@ -2049,6 +2655,11 @@ QTabWidget::tab-bar {
               <layout class="QVBoxLayout" name="verticalLayout_6">
                <item>
                 <widget class="QTreeWidget" name="treeWidget">
+                 <property name="font">
+                  <font>
+                   <pointsize>5</pointsize>
+                  </font>
+                 </property>
                  <property name="alternatingRowColors">
                   <bool>true</bool>
                  </property>
@@ -2087,6 +2698,11 @@ QTabWidget::tab-bar {
                    <height>150</height>
                   </size>
                  </property>
+                 <property name="font">
+                  <font>
+                   <pointsize>5</pointsize>
+                  </font>
+                 </property>
                  <property name="frameShape">
                   <enum>QFrame::StyledPanel</enum>
                  </property>
@@ -2101,6 +2717,11 @@ QTabWidget::tab-bar {
                     <width>71</width>
                     <height>20</height>
                    </rect>
+                  </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>5</pointsize>
+                   </font>
                   </property>
                   <property name="text">
                    <string>Node Name</string>
@@ -2118,6 +2739,11 @@ QTabWidget::tab-bar {
                     <height>20</height>
                    </rect>
                   </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>5</pointsize>
+                   </font>
+                  </property>
                  </widget>
                  <widget class="QLineEdit" name="lineEdit_4">
                   <property name="geometry">
@@ -2127,6 +2753,11 @@ QTabWidget::tab-bar {
                     <width>89</width>
                     <height>20</height>
                    </rect>
+                  </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>5</pointsize>
+                   </font>
                   </property>
                  </widget>
                  <widget class="QLineEdit" name="lineEdit_5">
@@ -2138,6 +2769,11 @@ QTabWidget::tab-bar {
                     <height>20</height>
                    </rect>
                   </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>5</pointsize>
+                   </font>
+                  </property>
                  </widget>
                  <widget class="QLineEdit" name="lineEdit_2">
                   <property name="geometry">
@@ -2148,6 +2784,11 @@ QTabWidget::tab-bar {
                     <height>20</height>
                    </rect>
                   </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>5</pointsize>
+                   </font>
+                  </property>
                  </widget>
                  <widget class="QLabel" name="label_2">
                   <property name="geometry">
@@ -2157,6 +2798,11 @@ QTabWidget::tab-bar {
                     <width>31</width>
                     <height>21</height>
                    </rect>
+                  </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>5</pointsize>
+                   </font>
                   </property>
                   <property name="text">
                    <string>LocX</string>
@@ -2174,6 +2820,11 @@ QTabWidget::tab-bar {
                     <height>21</height>
                    </rect>
                   </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>5</pointsize>
+                   </font>
+                  </property>
                   <property name="text">
                    <string>LocY</string>
                   </property>
@@ -2189,6 +2840,11 @@ QTabWidget::tab-bar {
                     <width>31</width>
                     <height>21</height>
                    </rect>
+                  </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>5</pointsize>
+                   </font>
                   </property>
                   <property name="text">
                    <string>LocZ</string>
@@ -2206,6 +2862,11 @@ QTabWidget::tab-bar {
                     <height>21</height>
                    </rect>
                   </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>5</pointsize>
+                   </font>
+                  </property>
                   <property name="text">
                    <string>Properties</string>
                   </property>
@@ -2219,11 +2880,16 @@ QTabWidget::tab-bar {
                   </property>
                   <property name="geometry">
                    <rect>
-                    <x>170</x>
-                    <y>100</y>
+                    <x>200</x>
+                    <y>111</y>
                     <width>101</width>
-                    <height>31</height>
+                    <height>35</height>
                    </rect>
+                  </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>5</pointsize>
+                   </font>
                   </property>
                   <property name="text">
                    <string>Apply</string>
@@ -2238,6 +2904,11 @@ QTabWidget::tab-bar {
                     <height>21</height>
                    </rect>
                   </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>5</pointsize>
+                   </font>
+                  </property>
                   <property name="text">
                    <string/>
                   </property>
@@ -2251,6 +2922,11 @@ QTabWidget::tab-bar {
                     <height>20</height>
                    </rect>
                   </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>5</pointsize>
+                   </font>
+                  </property>
                  </widget>
                  <widget class="QLabel" name="label_7">
                   <property name="geometry">
@@ -2261,6 +2937,11 @@ QTabWidget::tab-bar {
                     <height>21</height>
                    </rect>
                   </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>5</pointsize>
+                   </font>
+                  </property>
                   <property name="text">
                    <string>ID</string>
                   </property>
@@ -2268,11 +2949,16 @@ QTabWidget::tab-bar {
                  <widget class="QPushButton" name="pushButton_13">
                   <property name="geometry">
                    <rect>
-                    <x>170</x>
-                    <y>30</y>
+                    <x>200</x>
+                    <y>37</y>
                     <width>101</width>
-                    <height>28</height>
+                    <height>35</height>
                    </rect>
+                  </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>5</pointsize>
+                   </font>
                   </property>
                   <property name="text">
                    <string>New Group</string>
@@ -2281,11 +2967,16 @@ QTabWidget::tab-bar {
                  <widget class="QPushButton" name="pushButton_14">
                   <property name="geometry">
                    <rect>
-                    <x>170</x>
-                    <y>60</y>
+                    <x>200</x>
+                    <y>74</y>
                     <width>101</width>
-                    <height>28</height>
+                    <height>35</height>
                    </rect>
+                  </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>5</pointsize>
+                   </font>
                   </property>
                   <property name="text">
                    <string>Move to Group</string>
@@ -2294,11 +2985,16 @@ QTabWidget::tab-bar {
                  <widget class="QPushButton" name="pushButton_20">
                   <property name="geometry">
                    <rect>
-                    <x>170</x>
+                    <x>200</x>
                     <y>0</y>
                     <width>101</width>
-                    <height>28</height>
+                    <height>35</height>
                    </rect>
+                  </property>
+                  <property name="font">
+                   <font>
+                    <pointsize>5</pointsize>
+                   </font>
                   </property>
                   <property name="text">
                    <string>Hide all</string>
@@ -2311,6 +3007,11 @@ QTabWidget::tab-bar {
             </layout>
            </widget>
            <widget class="QWidget" name="tab_beams">
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
+            </property>
             <attribute name="title">
              <string>Beams</string>
             </attribute>
@@ -2332,6 +3033,11 @@ QTabWidget::tab-bar {
              </property>
              <item>
               <widget class="QTreeWidget" name="treeWidget_2">
+               <property name="font">
+                <font>
+                 <pointsize>5</pointsize>
+                </font>
+               </property>
                <property name="selectionMode">
                 <enum>QAbstractItemView::ExtendedSelection</enum>
                </property>
@@ -2359,6 +3065,11 @@ QTabWidget::tab-bar {
                  <height>170</height>
                 </size>
                </property>
+               <property name="font">
+                <font>
+                 <pointsize>5</pointsize>
+                </font>
+               </property>
                <property name="title">
                 <string>Beam properties</string>
                </property>
@@ -2366,40 +3077,60 @@ QTabWidget::tab-bar {
                 <property name="geometry">
                  <rect>
                   <x>70</x>
-                  <y>50</y>
+                  <y>70</y>
                   <width>61</width>
-                  <height>22</height>
+                  <height>30</height>
                  </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>5</pointsize>
+                 </font>
                 </property>
                </widget>
                <widget class="QLineEdit" name="lineEdit_7">
                 <property name="geometry">
                  <rect>
                   <x>70</x>
-                  <y>70</y>
+                  <y>100</y>
                   <width>61</width>
-                  <height>22</height>
+                  <height>30</height>
                  </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>5</pointsize>
+                 </font>
                 </property>
                </widget>
                <widget class="QLineEdit" name="lineEdit_8">
                 <property name="geometry">
                  <rect>
                   <x>70</x>
-                  <y>90</y>
+                  <y>130</y>
                   <width>61</width>
-                  <height>22</height>
+                  <height>30</height>
                  </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>5</pointsize>
+                 </font>
                 </property>
                </widget>
                <widget class="QLabel" name="label_5">
                 <property name="geometry">
                  <rect>
                   <x>10</x>
-                  <y>50</y>
+                  <y>70</y>
                   <width>53</width>
-                  <height>21</height>
+                  <height>30</height>
                  </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>5</pointsize>
+                 </font>
                 </property>
                 <property name="text">
                  <string>Node 1</string>
@@ -2412,10 +3143,15 @@ QTabWidget::tab-bar {
                 <property name="geometry">
                  <rect>
                   <x>10</x>
-                  <y>70</y>
+                  <y>100</y>
                   <width>53</width>
-                  <height>21</height>
+                  <height>30</height>
                  </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>5</pointsize>
+                 </font>
                 </property>
                 <property name="text">
                  <string>Node 2</string>
@@ -2428,10 +3164,15 @@ QTabWidget::tab-bar {
                 <property name="geometry">
                  <rect>
                   <x>0</x>
-                  <y>90</y>
+                  <y>130</y>
                   <width>61</width>
-                  <height>21</height>
+                  <height>30</height>
                  </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>5</pointsize>
+                 </font>
                 </property>
                 <property name="text">
                  <string>Properties</string>
@@ -2443,11 +3184,16 @@ QTabWidget::tab-bar {
                <widget class="QPushButton" name="pushButton_15">
                 <property name="geometry">
                  <rect>
-                  <x>140</x>
-                  <y>80</y>
+                  <x>180</x>
+                  <y>82</y>
                   <width>101</width>
-                  <height>31</height>
+                  <height>35</height>
                  </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>5</pointsize>
+                 </font>
                 </property>
                 <property name="text">
                  <string>Apply</string>
@@ -2456,11 +3202,16 @@ QTabWidget::tab-bar {
                <widget class="QPushButton" name="pushButton_16">
                 <property name="geometry">
                  <rect>
-                  <x>140</x>
-                  <y>20</y>
+                  <x>180</x>
+                  <y>8</y>
                   <width>101</width>
-                  <height>28</height>
+                  <height>35</height>
                  </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>5</pointsize>
+                 </font>
                 </property>
                 <property name="text">
                  <string>New Group</string>
@@ -2469,11 +3220,16 @@ QTabWidget::tab-bar {
                <widget class="QPushButton" name="pushButton_17">
                 <property name="geometry">
                  <rect>
-                  <x>140</x>
-                  <y>50</y>
+                  <x>180</x>
+                  <y>45</y>
                   <width>101</width>
-                  <height>28</height>
+                  <height>35</height>
                  </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>5</pointsize>
+                 </font>
                 </property>
                 <property name="text">
                  <string>Move to Group</string>
@@ -2482,11 +3238,16 @@ QTabWidget::tab-bar {
                <widget class="QPushButton" name="pushButton_21_hidebeams">
                 <property name="geometry">
                  <rect>
-                  <x>30</x>
-                  <y>20</y>
+                  <x>40</x>
+                  <y>25</y>
                   <width>93</width>
-                  <height>28</height>
+                  <height>35</height>
                  </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>5</pointsize>
+                 </font>
                 </property>
                 <property name="text">
                  <string>Hide all</string>
@@ -2501,6 +3262,11 @@ QTabWidget::tab-bar {
                   <height>16</height>
                  </rect>
                 </property>
+                <property name="font">
+                 <font>
+                  <pointsize>5</pointsize>
+                 </font>
+                </property>
                 <property name="text">
                  <string/>
                 </property>
@@ -2508,11 +3274,16 @@ QTabWidget::tab-bar {
                <widget class="QPushButton" name="pushButton_21">
                 <property name="geometry">
                  <rect>
-                  <x>140</x>
-                  <y>130</y>
+                  <x>180</x>
+                  <y>119</y>
                   <width>101</width>
-                  <height>28</height>
+                  <height>35</height>
                  </rect>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>5</pointsize>
+                 </font>
                 </property>
                 <property name="toolTip">
                  <string>Choose arguments for selected beams</string>
@@ -2526,6 +3297,11 @@ QTabWidget::tab-bar {
             </layout>
            </widget>
            <widget class="QWidget" name="tab_5_lua">
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
+            </property>
             <attribute name="title">
              <string>Script</string>
             </attribute>
@@ -2554,6 +3330,11 @@ QTabWidget::tab-bar {
       </item>
       <item>
        <widget class="QFrame" name="frame_11">
+        <property name="font">
+         <font>
+          <pointsize>5</pointsize>
+         </font>
+        </property>
         <property name="frameShape">
          <enum>QFrame::StyledPanel</enum>
         </property>
@@ -2587,6 +3368,11 @@ QTabWidget::tab-bar {
              <height>30</height>
             </size>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>5</pointsize>
+            </font>
+           </property>
            <property name="frameShape">
             <enum>QFrame::StyledPanel</enum>
            </property>
@@ -2599,11 +3385,16 @@ QTabWidget::tab-bar {
             </property>
             <property name="geometry">
              <rect>
-              <x>80</x>
+              <x>90</x>
               <y>0</y>
-              <width>111</width>
+              <width>110</width>
               <height>31</height>
              </rect>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
             </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
@@ -2618,15 +3409,25 @@ QTabWidget::tab-bar {
               <height>31</height>
              </rect>
             </property>
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
+            </property>
            </widget>
            <widget class="QSpinBox" name="spinBox">
             <property name="geometry">
              <rect>
-              <x>10</x>
+              <x>0</x>
               <y>0</y>
               <width>91</width>
               <height>31</height>
              </rect>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>5</pointsize>
+             </font>
             </property>
             <property name="toolTip">
              <string>View zoom</string>
@@ -2658,14 +3459,24 @@ QTabWidget::tab-bar {
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1159</width>
-     <height>26</height>
+     <width>1485</width>
+     <height>23</height>
     </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>5</pointsize>
+    </font>
    </property>
    <property name="autoFillBackground">
     <bool>true</bool>
    </property>
    <widget class="QMenu" name="menuFile">
+    <property name="font">
+     <font>
+      <pointsize>5</pointsize>
+     </font>
+    </property>
     <property name="title">
      <string>File</string>
     </property>
@@ -2689,12 +3500,22 @@ QTabWidget::tab-bar {
     <addaction name="actionExit"/>
    </widget>
    <widget class="QMenu" name="menuEdit">
+    <property name="font">
+     <font>
+      <pointsize>5</pointsize>
+     </font>
+    </property>
     <property name="title">
      <string>Edit</string>
     </property>
     <addaction name="actionSettings"/>
    </widget>
    <widget class="QMenu" name="menuGenerate">
+    <property name="font">
+     <font>
+      <pointsize>5</pointsize>
+     </font>
+    </property>
     <property name="title">
      <string>Scripts</string>
     </property>
@@ -2702,6 +3523,11 @@ QTabWidget::tab-bar {
     <addaction name="actionRun_again"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
+    <property name="font">
+     <font>
+      <pointsize>5</pointsize>
+     </font>
+    </property>
     <property name="title">
      <string>Help</string>
     </property>
@@ -2711,6 +3537,11 @@ QTabWidget::tab-bar {
     <addaction name="actionAbout"/>
    </widget>
    <widget class="QMenu" name="menuView">
+    <property name="font">
+     <font>
+      <pointsize>5</pointsize>
+     </font>
+    </property>
     <property name="title">
      <string>View</string>
     </property>

--- a/source/processbar.ui
+++ b/source/processbar.ui
@@ -30,9 +30,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>40</y>
+     <y>20</y>
      <width>381</width>
-     <height>31</height>
+     <height>50</height>
     </rect>
    </property>
    <property name="value">

--- a/source/settings.ui
+++ b/source/settings.ui
@@ -22,6 +22,11 @@
      <height>41</height>
     </rect>
    </property>
+   <property name="font">
+    <font>
+     <pointsize>8</pointsize>
+    </font>
+   </property>
    <property name="orientation">
     <enum>Qt::Horizontal</enum>
    </property>
@@ -40,6 +45,11 @@
      <width>471</width>
      <height>331</height>
     </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>5</pointsize>
+    </font>
    </property>
    <property name="currentIndex">
     <number>0</number>
@@ -85,9 +95,9 @@
      <property name="geometry">
       <rect>
        <x>0</x>
-       <y>0</y>
-       <width>451</width>
-       <height>41</height>
+       <y>-10</y>
+       <width>440</width>
+       <height>50</height>
       </rect>
      </property>
      <property name="font">
@@ -107,7 +117,7 @@
        <x>0</x>
        <y>170</y>
        <width>461</width>
-       <height>51</height>
+       <height>70</height>
       </rect>
      </property>
      <property name="frameShape">
@@ -122,7 +132,7 @@
         <x>0</x>
         <y>0</y>
         <width>251</width>
-        <height>41</height>
+        <height>20</height>
        </rect>
       </property>
       <property name="text">
@@ -135,7 +145,7 @@
         <x>260</x>
         <y>0</y>
         <width>161</width>
-        <height>20</height>
+        <height>30</height>
        </rect>
       </property>
       <property name="text">
@@ -146,9 +156,9 @@
       <property name="geometry">
        <rect>
         <x>260</x>
-        <y>20</y>
+        <y>40</y>
         <width>161</width>
-        <height>20</height>
+        <height>30</height>
        </rect>
       </property>
       <property name="text">
@@ -257,9 +267,9 @@
      <property name="geometry">
       <rect>
        <x>0</x>
-       <y>0</y>
+       <y>-10</y>
        <width>451</width>
-       <height>41</height>
+       <height>50</height>
       </rect>
      </property>
      <property name="font">
@@ -267,6 +277,8 @@
        <pointsize>12</pointsize>
        <weight>75</weight>
        <bold>true</bold>
+       <underline>false</underline>
+       <kerning>true</kerning>
       </font>
      </property>
      <property name="text">
@@ -374,9 +386,9 @@
      <property name="geometry">
       <rect>
        <x>0</x>
-       <y>0</y>
-       <width>451</width>
-       <height>41</height>
+       <y>-10</y>
+       <width>440</width>
+       <height>50</height>
       </rect>
      </property>
      <property name="font">


### PR DESCRIPTION
@RORMasa , I had imported your project with the older version of qt and made a few minor changes:

1) UI scaling modifications: moved around some elements and changed the textsize for all elements, so it is no longer neccesary to modify the scaling properties when using the app on windows (10/11)
2) Changed the keybindings to: 
    `A`/`LeftArrow`      Move left
    `D`/`RightArrow`   Move right
    `W`/`UpArrow`      Move forward
    `S`/`DownArrow`   Move backwards
    `E`                            Move up
    `Q`                           Move down
    `+`                           Zoom In (technically same command as E) 
    `-`                            Zoom Out (technically same command as Q)
    
    Possibly going to work on making the zoom keys actually zoom, but for now works for me at least :-)

Anyways, I was hoping for your permission to repost the updates on the beamng forums (_after a bit more work on it, trying to update the UI to the latest QT/QTCreator_). 

If you do not want me to do this it is completely fine, and I will not post anything (such as generated binary builds) in those forums unless approved by you ;-) 

I just noticed there were some requests there (in the forums) for these changes in keyboard shortcuts, as well as the mentioned scaling issues. I love the program and was sad to see you are no longer working on the project. Note that I am also happy to take over the development of it if that is something you are interested in. Of course all credit will be retained to you, as I am really not doing much besides some minor tweaks to the UI and settings. 

Best, 
hltdev
